### PR TITLE
Minor change to README.md for including postgis in the installation.

### DIFF
--- a/personal-odc-db/README.md
+++ b/personal-odc-db/README.md
@@ -34,7 +34,7 @@ Steps:
 
        micromamba create --prefix ~/postgresql --yes postgresql
 
-       (Optional) Include `postgis` with the installation:
+    (Optional) Include `postgis` with the installation:
 
        micromamba create --prefix ~/postgresql --yes postgresql postgis
 

--- a/personal-odc-db/README.md
+++ b/personal-odc-db/README.md
@@ -1,3 +1,4 @@
+
 # Running a personal ODC Database
 
 Normally, you don't have write access to the ODC Database, so you can't create new Products and Datasets.
@@ -32,6 +33,10 @@ Steps:
 2. Download and install PostgreSQL into ~/postgresql.
 
        micromamba create --prefix ~/postgresql --yes postgresql
+
+       (Optional) Include `postgis` with the installation:
+
+       micromamba create --prefix ~/postgresql --yes postgresql postgis
 
 3. Initialise a Postgres Data Dir, Launch Postgres locally, and create an empty datacube DB.
 


### PR DESCRIPTION
Minor addition to `README.md` for including `postgis` in the installation.

This was useful in testing [datacube-ows](https://github.com/opendatacube/datacube-ows) locally with [personal-odc-db](https://github.com/csiro-easi/easi-cookbook/tree/main/personal-odc-db)